### PR TITLE
Configure kiss device

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+Paul McMillan

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,1 +1,1 @@
-Copyright 2013, OnBeep, Inc.
+Copyright 2013, OnBeep, Inc. and Contributors

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2013 OnBeep, Inc.
+Copyright 2013 OnBeep, Inc. and Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Source:: https://github.com/ampledata/kiss
 # Author:: Greg Albrecht W2GMD <gba@onbeep.com>
-# Copyright:: Copyright 2013 OnBeep, Inc.
+# Copyright:: Copyright 2013 OnBeep, Inc. and Contributors
 # License:: Apache License, Version 2.0
 #
 

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ http://ampledata.org/
 
 Copyright
 =========
-Copyright 2013 OnBeep, Inc.
+Copyright 2013 OnBeep, Inc. and Contributors
 
 
 License

--- a/kiss/__init__.py
+++ b/kiss/__init__.py
@@ -9,7 +9,7 @@ KISS Python Module.
 
 
 :author: Greg Albrecht W2GMD <gba@onbeep.com>
-:copyright: Copyright 2013 OnBeep, Inc.
+:copyright: Copyright 2013 OnBeep, Inc. and Contributors
 :license: Apache License, Version 2.0
 :source: <https://github.com/ampledata/kiss>
 
@@ -17,7 +17,7 @@ KISS Python Module.
 
 __author__ = 'Greg Albrecht W2GMD <gba@onbeep.com>'
 __license__ = 'Apache License, Version 2.0'
-__copyright__ = 'Copyright 2013 OnBeep, Inc.'
+__copyright__ = 'Copyright 2013 OnBeep, Inc. and Contributors'
 
 
 import logging

--- a/kiss/classes.py
+++ b/kiss/classes.py
@@ -4,7 +4,7 @@
 """KISS Core Classes."""
 
 __author__ = 'Greg Albrecht W2GMD <gba@onbeep.com>'
-__copyright__ = 'Copyright 2013 OnBeep, Inc.'
+__copyright__ = 'Copyright 2013 OnBeep, Inc. and Contributors'
 __license__ = 'Apache License, Version 2.0'
 
 

--- a/kiss/constants.py
+++ b/kiss/constants.py
@@ -4,7 +4,7 @@
 """Constants for KISS Python Module."""
 
 __author__ = 'Greg Albrecht W2GMD <gba@onbeep.com>'
-__copyright__ = 'Copyright 2013 OnBeep, Inc.'
+__copyright__ = 'Copyright 2013 OnBeep, Inc. and Contributors'
 __license__ = 'Apache License, Version 2.0'
 
 

--- a/kiss/util.py
+++ b/kiss/util.py
@@ -4,7 +4,7 @@
 """Utilities for the KISS Python Module."""
 
 __author__ = 'Greg Albrecht W2GMD <gba@onbeep.com>'
-__copyright__ = 'Copyright 2013 OnBeep, Inc.'
+__copyright__ = 'Copyright 2013 OnBeep, Inc. and Contributors'
 __license__ = 'Apache License, Version 2.0'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # Source:: https://github.com/ampledata/kiss
 # Author:: Greg Albrecht W2GMD <gba@onbeep.com>
-# Copyright:: Copyright 2013 OnBeep, Inc.
+# Copyright:: Copyright 2013 OnBeep, Inc. and Contributors
 # License:: Apache License, Version 2.0
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # Source:: https://github.com/ampledata/kiss
 # Author:: Greg Albrecht W2GMD <gba@onbeep.com>
-# Copyright:: Copyright 2013 OnBeep, Inc.
+# Copyright:: Copyright 2013 OnBeep, Inc. and Contributors
 # License:: Apache License, Version 2.0
 #
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ __title__ = 'kiss'
 __version__ = '1.0.1'
 __build__ = '0x010001'
 __author__ = 'Greg Albrecht W2GMD <gba@onbeep.com>'
-__copyright__ = 'Copyright 2013 OnBeep, Inc.'
+__copyright__ = 'Copyright 2013 OnBeep, Inc. and Contributors'
 __license__ = 'Apache License, Version 2.0'
 
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -4,7 +4,7 @@
 """Constants for KISS Module Tests."""
 
 __author__ = 'Greg Albrecht W2GMD <gba@onbeep.com>'
-__copyright__ = 'Copyright 2013 OnBeep, Inc.'
+__copyright__ = 'Copyright 2013 OnBeep, Inc. and Contributors'
 __license__ = 'Apache License, Version 2.0'
 
 

--- a/tests/test_kiss_util.py
+++ b/tests/test_kiss_util.py
@@ -4,7 +4,7 @@
 """Tests for KISS Util Module."""
 
 __author__ = 'Greg Albrecht W2GMD <gba@onbeep.com>'
-__copyright__ = 'Copyright 2013 OnBeep, Inc.'
+__copyright__ = 'Copyright 2013 OnBeep, Inc. and Contributors'
 __license__ = 'Apache License, Version 2.0'
 
 


### PR DESCRIPTION
This patch makes configuration of the kiss device easy, and adds a reasonable set of default values for that. It also fixes up the pip command in the Makefile.

I went ahead and added "and Contributors" to all the license and copyright statements, and added a contributors file. That should be enough to satisfy the licensing requirements, and it means that when you get more contributors, there won't be extra pointless diffs with them adding their names to each file they touch. If you'd prefer to do this differently, I'm happy to oblige.

Thanks for releasing this under a reasonable license (insert generic rant about horrible ham licensing culture).
