### PR TITLE
Fix typo in classes.py

### DIFF
--- a/kiss/classes.py
+++ b/kiss/classes.py
@@ -190,7 +190,7 @@ class KISS(object):
         self._logger.debug(
             'frame_escaped(%s)="%s"', len(frame_escaped), frame_escaped)
 
-        frame_kiss = ''.join([
+        frame_kiss = b''.join([
             kiss.FEND,
             kiss.DATA_FRAME,
             frame_escaped,


### PR DESCRIPTION
This typo causes issues merging these byte constants in python3