### PR TITLE
String-ify sections of code

### DIFF
--- a/kiss/classes.py
+++ b/kiss/classes.py
@@ -191,15 +191,15 @@ class KISS(object):
             'frame_escaped(%s)="%s"', len(frame_escaped), frame_escaped)
 
         frame_kiss = ''.join([
-            kiss.FEND,
-            kiss.DATA_FRAME,
+            str(kiss.FEND),
+            str(kiss.DATA_FRAME),
             frame_escaped,
-            kiss.FEND
+            str(kiss.FEND)
         ])
         self._logger.debug(
             'frame_kiss(%s)="%s"', len(frame_kiss), frame_kiss)
 
-        self._write_handler(frame_kiss)
+        self._write_handler(bytes(frame_kiss, "utf-8"))
 
 
 class TCPKISS(KISS):

--- a/kiss/util.py
+++ b/kiss/util.py
@@ -20,11 +20,11 @@ def escape_special_codes(raw_codes):
     - http://en.wikipedia.org/wiki/KISS_(TNC)#Description
     """
     return raw_codes.replace(
-        kiss.FESC,
-        kiss.FESC_TFESC
+        str(kiss.FESC),
+        str(kiss.FESC_TFESC)
     ).replace(
-        kiss.FEND,
-        kiss.FESC_TFEND
+        str(kiss.FEND),
+        str(kiss.FESC_TFEND)
     )
 
 


### PR DESCRIPTION
I think something must have changed regarding .replace and .join, no longer accepting bytes and strings together, so i messily fixed them just enough to work, a better solution would maybe be to work ONLY with bytes, or work ONLY with strings.